### PR TITLE
fix autonc: unloaded reset bug

### DIFF
--- a/verilogpp
+++ b/verilogpp
@@ -1769,11 +1769,6 @@ sub keep_track_of_used_net {
   my $mapped_signal = shift;
   my $mapper = shift;
 
-  return if ($signal eq 'clk');
-  return if ($signal eq 'rst');
-  return if ($signal eq $main::config{"clock"});
-  return if ($signal eq $main::config{"reset_n"});
-
   my $port = $prototype->GetPortByName($signal);
   my $normalized_net = $mapped_signal;
   $normalized_net =~ s/\s*\[ [^\]]* \]\s*//gx;  # strip away slice operators.
@@ -2598,6 +2593,12 @@ sub expand_autonet($$) {
     if ($my_interface->HasPort($s)) {
       next;
     }
+
+    # for apocryphal reasons / backwards compatibility:
+    next if ($s eq 'clk');
+    next if ($s eq 'rst');
+    next if ($s eq $main::config{"clock"});
+    next if ($s eq $main::config{"reset_n"});
 
     # Skip constants and expressions
     next unless ($s =~ m/[[:alpha:]]/);  # Must have a letter

--- a/verilogpp_tests/autonc4.vpp
+++ b/verilogpp_tests/autonc4.vpp
@@ -1,0 +1,84 @@
+// inst_of_unpacked instantiates an unpacked from unpacked.v
+
+module inst_of_unpacked (
+  input wire clk,
+  input wire reset_n,
+  output [7:0] fee [0:10-1],
+  input wire       fee_en[0:5],
+  input wire [7:0] fie[0:5],
+  input wire       fie_en[0:5]
+);
+
+/**AUTONET --init **/
+/*PPSTART*/
+wire [7:0] another_output;
+wire [7:0] bar;
+wire  derived;
+wire [7:0] foo[0:5];
+wire  foo_en[0:5];
+/*PPSTOP*/
+
+assign foo_en[0] = bar;
+assign foo_en[1] = bar && another_output;
+
+/**AUTONC
+  /.+/
+**/
+/*PPSTART*/
+assign foo = '0;
+/*PPSTOP*/
+
+/**INST drive_one.v drive_one_derived
+  .foo(derived)
+**/
+/*PPSTART*/
+drive_one drive_one_derived (
+  .foo (derived)
+);
+/*PPSTOP*/
+
+
+/**INST unpacked.v u_unpacked --style=v2 --compact **/
+/*PPSTART*/
+unpacked u_unpacked (
+  .clk,      // input
+  .reset_n,  // input
+  .foo,      // input
+  .foo_en,   // input
+  .bar       // output
+);
+/*PPSTOP*/
+
+/**INST unpacked.v u_unpacked2 --style=v2 --compact
+parameter N 10
+s/^foo/fee/;
+.reset_n(derived)
+**/
+/*PPSTART*/
+unpacked #(
+  .N(10)
+) u_unpacked2 (
+  .clk,               // input
+  .reset_n (derived), // input
+  .foo     (fee),     // input
+  .foo_en  (fee_en),  // input
+  .bar                // output
+);
+/*PPSTOP*/
+
+/**INST unpacked.v u_unpacked3 --style=v2 --compact
+  .bar(another_output)
+  s/foo/fie/;
+**/
+/*PPSTART*/
+unpacked u_unpacked3 (
+  .clk,                      // input
+  .reset_n,                  // input
+  .foo      (fie),           // input
+  .foo_en   (fie_en),        // input
+  .bar      (another_output) // output
+);
+/*PPSTOP*/
+
+
+endmodule

--- a/verilogpp_tests/connect_n_to_n.vpp
+++ b/verilogpp_tests/connect_n_to_n.vpp
@@ -1,0 +1,36 @@
+module connect_to_array();
+
+/**AUTONET --init **/
+/*PPSTART*/
+wire  bar;
+/*PPSTOP*/
+
+/**FORINST drive_one.v drive_one 0 1
+  .foo(bar[${enumerator}])
+**/
+/*PPSTART*/
+drive_one drive_one_0 (
+  .foo (bar[0])
+);
+drive_one drive_one_1 (
+  .foo (bar[1])
+);
+/*PPSTOP*/
+
+for (genvar ii = 0; ii < 2; ii += 1) begin : g_sink
+/**INST sink_one.v sink_one
+  .foo(bar[ii])
+**/
+/*PPSTART*/
+sink_one sink_one (
+  .foo (bar[ii])
+);
+/*PPSTOP*/
+
+/**AUTONC**/
+/*PPSTART*/
+
+/*PPSTOP*/
+
+
+endmodule : connect_to_array

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,9 +1,10 @@
-559f2cd65440b194cde8753f20541fd5  ../verilogpp
+2fada9c33bf17e5cc124deb972235e2d  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp
+4313a969dcfa8480476ae6f251501a59  autonc4.vpp
 adf4397b7b5c4594f27499fc4dd750b7  autonet_skipif.vpp
 d8bf9099c93900253867a09b87c975c1  bar.vpp
 f53ad3ace68d13b0cfa962509f7aac7e  bus_keeper.v

--- a/verilogpp_tests/preproc.manifest.expected
+++ b/verilogpp_tests/preproc.manifest.expected
@@ -1,9 +1,10 @@
-559f2cd65440b194cde8753f20541fd5  ../verilogpp
+1057e63ec1b0873308ac8d6654d81cd8  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp
+4313a969dcfa8480476ae6f251501a59  autonc4.vpp
 adf4397b7b5c4594f27499fc4dd750b7  autonet_skipif.vpp
 d8bf9099c93900253867a09b87c975c1  bar.vpp
 f53ad3ace68d13b0cfa962509f7aac7e  bus_keeper.v


### PR DESCRIPTION
if a block implemented `.rst_n(some_derived_reset)`, `some_derived_reset` would be incorrectly annotated as unloaded and would appear in the `AUTONC` list.