### PR TITLE
Add v3 formatting style

### DIFF
--- a/verilogpp
+++ b/verilogpp
@@ -1292,7 +1292,7 @@ sub MakeCompatibleWith($$) {
 sub CountConnection {
   my $self = shift;
   my $dir = shift;
-  if ($dir =~ m/^modport /) { $dir = "modport"; }
+  if ($dir =~ m/^modport (\S+)/) { $dir = "modport"; $self->{intf_modport} = $1; }
   # Indicate that this signal is connected to a port of the indicated type.
   $self->{count}->{$dir} += 1;
 }
@@ -1345,7 +1345,7 @@ sub Declaration() {
   if ($width =~ m/(^(?:\s*signed)?\s*\[)|(^\s*$)/) {
     # net is an array or single-element:
     $r = [$type, $width, $s];
-  } else {
+  }  else {
     # array is a struct, so don't declare a nettype:
     $r = [$width, $s];
   }
@@ -1356,19 +1356,18 @@ sub Declaration() {
 # Returns an array of tokens forming a port declaration
 sub Port {
   my $self = shift;
-  my $dir = 'output';
+  my @return = ('output');
   if ($self->NumberOfConnections('inout') > 0) {
-    $dir = 'inout';
+    @return = ('inout');
   } elsif ($self->NumberOfConnections('output') == 0) {
-    $dir = 'input';
-  }
-  my @return = ($dir);
-  # A hack: if a port is named "_if", we assume it is an interface
-  # and doesn't need a direction.
-  if ($self->{width} =~ m/_if\b/) {
-    @return = ();
+    @return = ('input');
   }
   push @return, @{$self->Declaration(1)};
+  if ($self->NumberOfConnections('modport') == 1) {
+    # this is an interface.  Replace the first two elements.
+    shift @return for 1..2;
+    unshift(@return, $self->{intf_modport});
+  }
   return @return;
 }
 

--- a/verilogpp
+++ b/verilogpp
@@ -2632,6 +2632,11 @@ sub expand_autonet($$) {
     $skipif = 1;
   }
 
+  my $style = $main::config{"style"};
+  if ($macro =~ s/^(.*)--style=(\S+)/$1/) {
+    $style = $2;
+  }
+
   # parse the input and output ports of this module
   my $my_interface = new ModuleSpec()->parse_prototype($self->{text});
   $self->CountAssignments($my_interface);

--- a/verilogpp
+++ b/verilogpp
@@ -2190,7 +2190,7 @@ sub expand_instantiate_with_prototype {
         my $conjunction = ",\n";
         if ($i == $#params) { $conjunction = "\n"; }
         $param =~ m/.(\S+)\s*\((.+)\)/;
-        printf("  .%-30s (%s)%s", $1, $2, $conjunction);
+        printf("  .%-29s (%s)%s", $1, $2, $conjunction);
       }
       print ") ";
     }
@@ -2450,6 +2450,11 @@ sub expand_autointerface($$) {
   my $self = shift;
   my $macro = shift;
 
+  my $style = $main::config{"style"};
+  if ($macro =~ s/^(.*)--style=(\S+)/$1/) {
+    $style = $2;
+  }
+
   # parse the input and output ports of this module
   my $my_interface = new ModuleSpec()->parse_prototype($self->{text});
 
@@ -2489,7 +2494,22 @@ sub expand_autointerface($$) {
   }
 
   &main::Pad2DArray(\@ports, 2, 5);
-  print &main::TabularAlign(\@ports, ",\n"), "\n";
+  if ($style eq "v3") {
+    for my $i (0..$#ports) {
+      my @p = @{$ports[$i]};
+      @p = grep {!/^$/} @p;
+      if ($p[1] eq "input") { $p[1] = "input "; }
+      if ($p[1] eq "inout") { $p[1] = "inout "; }
+      print (join(" ", @p));
+      if ($i == $#ports) {
+        print "\n";
+      } else {
+        print ",\n";
+      }
+    }
+  } else {
+    print &main::TabularAlign(\@ports, ",\n"), "\n";
+  }
 }
 
 sub CountAssignments {

--- a/verilogpp
+++ b/verilogpp
@@ -2005,7 +2005,7 @@ module interface.
 Options:
 
 * --pretty  Turns on "pretty print" style (equivalent to --style=pretty).
-* --style   Sets the output style ("default", "v2", "pretty")
+* --style   Sets the output style ("default", "v2", "pretty", "v3")
 * --compact Use compact naming for ports whose names match the connecting
             signal (ie. ".clk" instead of ".clk(clk)").
 
@@ -2181,25 +2181,55 @@ sub expand_instantiate_with_prototype {
       print "${instancename} ();\n";
     }
     return;
-  }
-  # default style:
-  print "${mod} ";
-  # When in pretty-print mode, line up commas on the left
-  my $first_indent = ($prettyprint) ? "   " : "  ";
-  my $conjunction = ($prettyprint) ? "\n,  " : ",\n  ";
-  if (%{$mapper->{PARAMS}}) {
-    print "#(\n";
-    print $first_indent,
-          join($conjunction, @params),
-          ") ";
-  }
-  if ($#d >= 0) {
-    print "${instancename} (\n";
-    print $first_indent, join($conjunction, @d), "\n);\n";
+  } elsif ($style eq "v3") {
+    print "${mod} ";
+    if (%{$mapper->{PARAMS}}) {
+      print "#(\n";
+      for my $i (0..$#params) {
+        my $param = $params[$i];
+        my $conjunction = ",\n";
+        if ($i == $#params) { $conjunction = "\n"; }
+        $param =~ m/.(\S+)\s*\((.+)\)/;
+        printf("  .%-30s (%s)%s", $1, $2, $conjunction);
+      }
+      print ") ";
+    }
+    if ($#list_of_hookup_arrs >= 0) {
+      print "${instancename} (\n";
+      for my $i (0..$#list_of_hookup_arrs) {
+        my @hookup_arr = @{$list_of_hookup_arrs[$i]};
+        if ($hookup_arr[1] eq "") {
+          printf "  %-61s  %s\n", $hookup_arr[0], $hookup_arr[2];
+        } else {
+          printf "  %-30s %-30s  %s\n", $hookup_arr[0], $hookup_arr[1], $hookup_arr[2];
+        }
+      }
+      print(");\n")
+    } else {
+      # module has no ports.
+      print "${instancename} ();\n";
+    }
+    return;
   } else {
-    # module has no ports.
-    print "${instancename} ();\n";
-  }
+    # default style:
+    print "${mod} ";
+    # When in pretty-print mode, line up commas on the left
+    my $first_indent = ($prettyprint) ? "   " : "  ";
+    my $conjunction = ($prettyprint) ? "\n,  " : ",\n  ";
+    if (%{$mapper->{PARAMS}}) {
+      print "#(\n";
+      print $first_indent,
+            join($conjunction, @params),
+            ") ";
+    }
+    if ($#d >= 0) {
+      print "${instancename} (\n";
+      print $first_indent, join($conjunction, @d), "\n);\n";
+    } else {
+      # module has no ports.
+      print "${instancename} ();\n";
+    }
+  }  # end of style select
 }
 
 $MacroHelp{'AUTOINC'} = <<EOT ;

--- a/verilogpp_tests/autoif_v3.vpp
+++ b/verilogpp_tests/autoif_v3.vpp
@@ -1,0 +1,50 @@
+// inst_of_unpacked instantiates an unpacked from unpacked.v
+
+module inst_of_unpacked (
+  input wire clk,
+  input wire reset_n,
+  output [7:0] fee [0:10-1],
+  /**AUTOINTERFACE --style=v3 **/
+/*PPSTART*/
+  output wire [7:0] bar,
+  input  wire fee_en[0:10-1],
+  input  wire [7:0] foo[0:5],
+  input  wire foo_en[0:5]
+/*PPSTOP*/
+);
+
+/**AUTONET --init **/
+/*PPSTART*/
+
+/*PPSTOP*/
+
+
+/**INST unpacked.v u_unpacked --style=v3 **/
+/*PPSTART*/
+unpacked u_unpacked (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .foo,                                                          // input
+  .foo_en,                                                       // input
+  .bar                                                           // output
+);
+/*PPSTOP*/
+
+/**INST unpackedN.v u_unpackedN --style=v3
+parameter N 10
+s/^foo/fee/;
+**/
+/*PPSTART*/
+unpackedN #(
+  .N                             (10)
+) u_unpackedN (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .foo                           (fee),                          // input
+  .foo_en                        (fee_en),                       // input
+  .bar                                                           // output
+);
+/*PPSTOP*/
+
+
+endmodule

--- a/verilogpp_tests/autointerface_with_interface.vpp
+++ b/verilogpp_tests/autointerface_with_interface.vpp
@@ -1,0 +1,33 @@
+// inst_of_unpacked instantiates an unpacked from unpacked.v
+
+module inst_of_mod_with_interface (
+  input wire clk,
+  input wire reset_n,
+  /**AUTOINTERFACE**/
+/*PPSTART*/
+  axi4_if.completer             axi,
+  output            wire [15:0] fwd_data,
+  input             wire        fwd_ready,
+  output            wire        fwd_valid
+/*PPSTOP*/
+);
+
+/**AUTONET**/
+/*PPSTART*/
+/*PPSTOP*/
+
+/**INST mod_with_interface.v mod_with_interface  --style=v2
+  .rst_n (reset_n)
+**/
+/*PPSTART*/
+mod_with_interfaced mod_with_interface (
+  .clk,                  // input
+  .rst_n      (reset_n), // input
+  .axi,                  // modport axi4_if.completer
+  .fwd_data,             // output
+  .fwd_valid,            // output
+  .fwd_ready             // input
+);
+/*PPSTOP*/
+
+endmodule

--- a/verilogpp_tests/autointerface_with_interface.vpp
+++ b/verilogpp_tests/autointerface_with_interface.vpp
@@ -14,6 +14,7 @@ module inst_of_mod_with_interface (
 
 /**AUTONET**/
 /*PPSTART*/
+
 /*PPSTOP*/
 
 /**INST mod_with_interface.v mod_with_interface  --style=v2

--- a/verilogpp_tests/instv3.vpp
+++ b/verilogpp_tests/instv3.vpp
@@ -1,0 +1,38 @@
+/**INST bus_keeper.v keeper7 --style=v3**/
+/*PPSTART*/
+bus_keeper keeper7 (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .busNNN_valid,                                                 // input
+  .busNNN_in,                                                    // input
+  .busNNN_out                                                    // output
+);
+/*PPSTOP*/
+
+
+/**FORINST bus_keeper.v keeper 1 2 3 --style=v3
+  s/NNN/${enumerator}/g;
+**/
+/*PPSTART*/
+bus_keeper keeper_1 (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .busNNN_valid                  (bus1_valid),                   // input
+  .busNNN_in                     (bus1_in),                      // input
+  .busNNN_out                    (bus1_out)                      // output
+);
+bus_keeper keeper_2 (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .busNNN_valid                  (bus2_valid),                   // input
+  .busNNN_in                     (bus2_in),                      // input
+  .busNNN_out                    (bus2_out)                      // output
+);
+bus_keeper keeper_3 (
+  .clk,                                                          // input
+  .reset_n,                                                      // input
+  .busNNN_valid                  (bus3_valid),                   // input
+  .busNNN_in                     (bus3_in),                      // input
+  .busNNN_out                    (bus3_out)                      // output
+);
+/*PPSTOP*/

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,6 +1,7 @@
-33b4b601787df0d1a929b2646546b21a  ../verilogpp
+6ed81ce92c9955ddee897422f6087193  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
+2e01d7d72ffa97188ad11041f6890c99  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,6 +1,7 @@
-dfbd4f76060c1277f9874ef5ab6d4496  ../verilogpp
+9ef4167253bde2fedc218c53e7a546fd  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
+bcafe31cdbc3425c992abed300acfbcb  autoif_v3.vpp
 2081fa73bc3e07c4f327902e67365f1f  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,4 +1,4 @@
-9ef4167253bde2fedc218c53e7a546fd  ../verilogpp
+e338047b09235c54a83d5626830dba9e  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
 bcafe31cdbc3425c992abed300acfbcb  autoif_v3.vpp

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,7 +1,7 @@
 dfbd4f76060c1277f9874ef5ab6d4496  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
-2e01d7d72ffa97188ad11041f6890c99  autointerface_with_interface.vpp
+2081fa73bc3e07c4f327902e67365f1f  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp

--- a/verilogpp_tests/preproc.manifest
+++ b/verilogpp_tests/preproc.manifest
@@ -1,4 +1,4 @@
-6ed81ce92c9955ddee897422f6087193  ../verilogpp
+dfbd4f76060c1277f9874ef5ab6d4496  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
 2e01d7d72ffa97188ad11041f6890c99  autointerface_with_interface.vpp
@@ -30,6 +30,7 @@ fe40f665771b6330bafa41add7135570  inst_of_typed_module.vpp
 bba772325acb574bf5f74edd944818d5  inst_of_unpacked.vpp
 6341c22c6d129c027a73582aa5407208  instpretty.vpp
 9e61861cb151968a07324288211f0603  instv2.vpp
+47d6aa5b76eb296a91fbb90f0f2c2d73  instv3.vpp
 4d568db3f89a79de93fb77cc20d69154  locparam.v
 7c439f5cdf30af3f4ddac68d373127dd  mark.vpp
 3e14e1391b4efd60fabaf617a4e8709e  missing_file.vpp

--- a/verilogpp_tests/preproc.manifest.expected
+++ b/verilogpp_tests/preproc.manifest.expected
@@ -1,6 +1,7 @@
-1057e63ec1b0873308ac8d6654d81cd8  ../verilogpp
+6ed81ce92c9955ddee897422f6087193  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
+2e01d7d72ffa97188ad11041f6890c99  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp

--- a/verilogpp_tests/preproc.manifest.expected
+++ b/verilogpp_tests/preproc.manifest.expected
@@ -1,6 +1,7 @@
-dfbd4f76060c1277f9874ef5ab6d4496  ../verilogpp
+9ef4167253bde2fedc218c53e7a546fd  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
+bcafe31cdbc3425c992abed300acfbcb  autoif_v3.vpp
 2081fa73bc3e07c4f327902e67365f1f  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp

--- a/verilogpp_tests/preproc.manifest.expected
+++ b/verilogpp_tests/preproc.manifest.expected
@@ -1,7 +1,7 @@
-6ed81ce92c9955ddee897422f6087193  ../verilogpp
+dfbd4f76060c1277f9874ef5ab6d4496  ../verilogpp
 ffa007a4806acae2aa22fae129423ebb  autocb.vpp
 e650ff66cc1639b0412f5194bcbeb6f0  autoif.vpp
-2e01d7d72ffa97188ad11041f6890c99  autointerface_with_interface.vpp
+2081fa73bc3e07c4f327902e67365f1f  autointerface_with_interface.vpp
 9590c1ebb34580fbc1e73b575bb94d74  autonc.vpp
 f87b0017fad53e4c8f74ce7950d325c9  autonc2.vpp
 20ece7df3404d1bc3b8fc7b2f24670f6  autonc3.vpp
@@ -30,6 +30,7 @@ fe40f665771b6330bafa41add7135570  inst_of_typed_module.vpp
 bba772325acb574bf5f74edd944818d5  inst_of_unpacked.vpp
 6341c22c6d129c027a73582aa5407208  instpretty.vpp
 9e61861cb151968a07324288211f0603  instv2.vpp
+47d6aa5b76eb296a91fbb90f0f2c2d73  instv3.vpp
 4d568db3f89a79de93fb77cc20d69154  locparam.v
 7c439f5cdf30af3f4ddac68d373127dd  mark.vpp
 3e14e1391b4efd60fabaf617a4e8709e  missing_file.vpp


### PR DESCRIPTION
v3 formatting style removes all TabularAlign formatting styles, and replaces them with printf-style fixed formatting.

The goal here is to get some aesthetic tabularization, but to remove the behavior where a change in one port name would change the formatting of a whole block.